### PR TITLE
Interface mode property

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,26 @@
----
+sudo: false
 language: ruby
 before_script: 'bundle exec rake fixture:prepare'
 script: 'SPEC_OPTS="--format documentation" bundle exec rake spec'
+rvm:
+  - 1.8.7
+  - 1.9.3
+  - 2.0.0
+  - 2.1
+env:
+  - PUPPET_GEM_VERSION="~> 2.7"
+  - PUPPET_GEM_VERSION="~> 3.3"
+  - PUPPET_GEM_VERSION="~> 3.7"
+matrix:
+  allow_failures:
+    - rvm: ruby-head
+  exclude:
+    - rvm: 1.9.3
+      env: PUPPET_GEM_VERSION="~> 2.7"
+    - rvm: 2.0.0
+      env: PUPPET_GEM_VERSION="~> 2.7"
+    - rvm: 2.1
+      env: PUPPET_GEM_VERSION="~> 2.7"
+  fast_finish: true
 notifications:
   email: false
-rvm:
-  - 1.9.3
-  - 1.8.7
-env:
-  - PUPPET_VERSION=2.7.21
-  - PUPPET_VERSION=3.0.2
-  - PUPPET_VERSION=3.1.0

--- a/lib/puppet/type/network_config.rb
+++ b/lib/puppet/type/network_config.rb
@@ -87,6 +87,14 @@ Puppet::Type.newtype(:network_config) do
     end
   end
 
+  newproperty(:mode) do
+    desc "The exclusive mode the interface should operate in"
+    # :bond and :bridge may be added in the future
+    newvalues(:raw, :vlan)
+
+    defaultto :raw
+  end
+
   # `:options` provides an arbitrary passthrough for provider properties, so
   # that provider specific behavior doesn't clutter up the main type but still
   # allows for more powerful actions to be taken.

--- a/spec/fixtures/provider/network_config/interfaces_spec/two_interfaces_static_vlan
+++ b/spec/fixtures/provider/network_config/interfaces_spec/two_interfaces_static_vlan
@@ -1,0 +1,23 @@
+# This file describes the network interfaces available on your system
+# and how to activate them. For more information, see interfaces(5).
+
+# The loopback network interface
+auto lo
+iface lo inet loopback
+
+# The primary network interface
+auto eth0
+iface eth0 inet static
+address 192.168.0.2
+broadcast 192.168.0.255
+netmask 255.255.255.0
+gateway 192.168.0.1
+mtu 1500
+auto eth0.1
+iface eth0.1 inet static
+vlan-raw-device eth0
+address 172.16.0.2
+broadcast 172.16.0.255
+netmask 255.255.255.0
+gateway 172.16.0.1
+mtu 1500

--- a/spec/unit/provider/network_config/redhat_spec.rb
+++ b/spec/unit/provider/network_config/redhat_spec.rb
@@ -182,7 +182,7 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
         subject { described_class.instances.find { |i| i.name == 'vlan100' } }
         its(:ipaddress) { should == '172.24.61.11' }
         its(:netmask)   { should == '255.255.255.0' }
-        its(:onboot)    { should be_false }
+        its(:onboot)    { should == :absent }
         its(:method)    { should == 'static' }
         its(:mode)      { should == :vlan }
         its(:options)   { should == {
@@ -197,16 +197,16 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
         subject { described_class.instances.find { |i| i.name == 'vlan100:0' } }
         its(:ipaddress) { should == '172.24.61.12' }
         its(:netmask)   { should == '255.255.255.0' }
-        its(:onboot)    { should be_false }
+        its(:onboot)    { should == :absent }
         its(:method)    { should == 'static' }
-        its(:options)   { should be_nil }
+        its(:options)   { should == :absent }
       end
 
       describe 'vlan200' do
         subject { described_class.instances.find { |i| i.name == 'vlan200' } }
         its(:ipaddress) { should == '172.24.62.1' }
         its(:netmask)   { should == '255.255.255.0' }
-        its(:onboot)    { should be_false }
+        its(:onboot)    { should == :absent }
         its(:method)    { should == 'static' }
         its(:mode)      { should == :vlan }
         its(:options)   { should == {
@@ -220,7 +220,7 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
         subject { described_class.instances.find { |i| i.name == 'vlan300' } }
         its(:ipaddress) { should == '172.24.63.1' }
         its(:netmask)   { should == '255.255.255.0' }
-        its(:onboot)    { should be_false }
+        its(:onboot)    { should == :absent }
         its(:method)    { should be_true }
         its(:mode)      { should == :vlan }
         its(:options)   { should == {
@@ -234,7 +234,7 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
         subject { described_class.instances.find { |i| i.name == 'vlan400' } }
         its(:ipaddress) { should == '172.24.64.1' }
         its(:netmask)   { should == '255.255.255.0' }
-        its(:onboot)    { should be_false }
+        its(:onboot)    { should == :absent }
         its(:method)    { should be_true }
         its(:mode)      { should == :vlan }
         its(:options)   { should == {
@@ -248,7 +248,7 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
         subject { described_class.instances.find { |i| i.name == 'vlan500' } }
         its(:ipaddress) { should == '172.24.65.1' }
         its(:netmask)   { should == '255.255.255.0' }
-        its(:onboot)    { should be_false }
+        its(:onboot)    { should == :absent }
         its(:method)    { should be_true }
         its(:mode)      { should == :vlan }
         its(:options)   { should == {

--- a/spec/unit/provider/network_config/redhat_spec.rb
+++ b/spec/unit/provider/network_config/redhat_spec.rb
@@ -130,6 +130,7 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
         subject { described_class.instances.find { |i| i.name == 'eth0' } }
         its(:onboot) { should be_true }
         its(:mtu) { should == '1500' }
+        its(:mode) { should == :raw }
         its(:options) { should == {
             'HWADDR' => '00:12:79:91:28:1f',
             'SLAVE'  => 'yes',
@@ -142,6 +143,7 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
         subject { described_class.instances.find { |i| i.name == 'eth1' } }
         its(:onboot) { should be_true }
         its(:mtu) { should == '1500' }
+        its(:mode) { should == :raw }
         its(:options) { should == {
             'HWADDR' => '00:12:79:91:28:20',
             'SLAVE'  => 'yes',
@@ -154,6 +156,7 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
         subject { described_class.instances.find { |i| i.name == 'eth2' } }
         its(:onboot) { should be_true }
         its(:mtu) { should == '1500' }
+        its(:mode) { should == :raw }
         its(:options) { should == {
             'HWADDR' => '00:26:55:e9:33:c4',
             'SLAVE'  => 'yes',
@@ -166,6 +169,7 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
         subject { described_class.instances.find { |i| i.name == 'eth3' } }
         its(:onboot) { should be_true }
         its(:mtu) { should == '1500' }
+        its(:mode) { should == :raw }
         its(:options) { should == {
             'HWADDR' => '00:26:55:e9:33:c5',
             'SLAVE'  => 'yes',
@@ -180,9 +184,9 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
         its(:netmask)   { should == '255.255.255.0' }
         its(:onboot)    { should be_false }
         its(:method)    { should == 'static' }
+        its(:mode)      { should == :vlan }
         its(:options)   { should == {
             'VLAN_NAME_TYPE' => 'VLAN_PLUS_VID_NO_PAD',
-            'VLAN'           => 'yes',
             'PHYSDEV'        => 'bond0',
             'GATEWAY'        => '172.24.61.1',
           }
@@ -204,9 +208,9 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
         its(:netmask)   { should == '255.255.255.0' }
         its(:onboot)    { should be_false }
         its(:method)    { should == 'static' }
+        its(:mode)      { should == :vlan }
         its(:options)   { should == {
             'VLAN_NAME_TYPE' => 'VLAN_PLUS_VID_NO_PAD',
-            'VLAN'           => 'yes',
             'PHYSDEV'        => 'bond0',
           }
         }
@@ -218,9 +222,9 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
         its(:netmask)   { should == '255.255.255.0' }
         its(:onboot)    { should be_false }
         its(:method)    { should be_true }
+        its(:mode)      { should == :vlan }
         its(:options)   { should == {
             'VLAN_NAME_TYPE' => 'VLAN_PLUS_VID_NO_PAD',
-            'VLAN'           => 'yes',
             'PHYSDEV'        => 'bond0',
           }
         }
@@ -232,9 +236,9 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
         its(:netmask)   { should == '255.255.255.0' }
         its(:onboot)    { should be_false }
         its(:method)    { should be_true }
+        its(:mode)      { should == :vlan }
         its(:options)   { should == {
             'VLAN_NAME_TYPE' => 'VLAN_PLUS_VID_NO_PAD',
-            'VLAN'           => 'yes',
             'PHYSDEV'        => 'bond0',
           }
         }
@@ -246,10 +250,64 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
         its(:netmask)   { should == '255.255.255.0' }
         its(:onboot)    { should be_false }
         its(:method)    { should be_true }
+        its(:mode)      { should == :vlan }
         its(:options)   { should == {
             'VLAN_NAME_TYPE' => 'VLAN_PLUS_VID_NO_PAD',
-            'VLAN'           => 'yes',
             'PHYSDEV'        => 'bond0',
+          }
+        }
+      end
+    end
+
+    describe 'interface.vlan_id vlan configuration' do
+      let(:network_scripts_path) { fixture_file('network-scripts') }
+
+      before do
+        described_class.stubs(:target_files).returns Dir["#{network_scripts_path}/*"]
+        described_class.any_instance.expects(:select_file).never
+      end
+
+      describe 'eth0.0' do
+        subject { described_class.instances.find { |i| i.name == 'eth0.0' } }
+        its(:onboot)  { should be_true }
+        its(:method)  { should == 'static' }
+        its(:mtu)     { should == '9000' }
+        its(:mode)    { should == :vlan }
+        its(:options) { should == {
+            'IPV6INIT'      => 'no',
+            'NM_CONTROLLED' => 'no',
+            'TYPE'          => 'Ethernet',
+            'BRIDGE'        => 'br1',
+          }
+        }
+      end
+
+      describe 'eth0.1' do
+        subject { described_class.instances.find { |i| i.name == 'eth0.1' } }
+        its(:onboot)  { should be_true }
+        its(:method)  { should == 'static' }
+        its(:mtu)     { should == '9000' }
+        its(:mode)    { should == :vlan }
+        its(:options) { should == {
+            'IPV6INIT'      => 'no',
+            'NM_CONTROLLED' => 'no',
+            'TYPE'          => 'Ethernet',
+            'BRIDGE'        => 'br1',
+          }
+        }
+      end
+
+      describe 'eth0.4095' do
+        subject { described_class.instances.find { |i| i.name == 'eth0.4095' } }
+        its(:onboot)  { should be_true }
+        its(:method)  { should == 'static' }
+        its(:mtu)     { should == '9000' }
+        its(:mode)    { should == :vlan }
+        its(:options) { should == {
+            'IPV6INIT'      => 'no',
+            'NM_CONTROLLED' => 'no',
+            'TYPE'          => 'Ethernet',
+            'BRIDGE'        => 'br4095',
           }
         }
       end
@@ -275,6 +333,23 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
         :ipaddress       => "169.254.0.1",
         :netmask         => "255.255.255.0",
         :mtu             => '1500',
+        :mode            => nil,
+        :options         => { "NM_CONTROLLED" => "no", "USERCTL" => "no"}
+      )
+    end
+
+    let(:eth0_1_provider) do
+      stub('eth0_1_provider',
+        :name            => "eth0.1",
+        :ensure          => :present,
+        :onboot          => true,
+        :hotplug         => true,
+        :family          => "inet",
+        :method          => "none",
+        :ipaddress       => "169.254.0.1",
+        :netmask         => "255.255.255.0",
+        :mtu             => '1500',
+        :mode            => :vlan,
         :options         => { "NM_CONTROLLED" => "no", "USERCTL" => "no"}
       )
     end
@@ -288,6 +363,7 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
         :method          => "loopback",
         :ipaddress       => nil,
         :netmask         => nil,
+        :mode            => nil,
         :options         => {}
       )
     end
@@ -301,6 +377,7 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
         :netmask   => '255.255.255.0',
         :method    => 'static',
         :mtu       => '1500',
+        :mode            => nil,
         :options   => {
           "BONDING_OPTS" => %{mode=4 miimon=100 xmit_hash_policy=layer3+4}
         }
@@ -322,6 +399,22 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
       it { data.should match /NETMASK=255\.255\.255\.0/ }
       it { data.should match /NM_CONTROLLED=no/ }
       it { data.should match /USERCTL=no/ }
+      # XXX should be be always managing VLAN?
+      it { data.should_not match /VLAN=yes/ }
+      it { data.should_not match /VLAN=no/ }
+    end
+
+    describe 'with test interface eth0.1' do
+      let(:data) { described_class.format_file('filepath', [eth0_1_provider]) }
+
+      it { data.should match /DEVICE=eth0.1/ }
+      it { data.should match /ONBOOT=yes/ }
+      it { data.should match /BOOTPROTO=none/ }
+      it { data.should match /IPADDR=169\.254\.0\.1/ }
+      it { data.should match /NETMASK=255\.255\.255\.0/ }
+      it { data.should match /NM_CONTROLLED=no/ }
+      it { data.should match /USERCTL=no/ }
+      it { data.should match /VLAN=yes/ }
     end
 
     describe 'with test interface bond0' do

--- a/spec/unit/type/network_config_spec.rb
+++ b/spec/unit/type/network_config_spec.rb
@@ -40,7 +40,7 @@ describe Puppet::Type.type(:network_config) do
       end
     end
 
-    [:ensure, :ipaddress, :netmask, :method, :family, :onboot, :mtu, :options].each do |property|
+    [:ensure, :ipaddress, :netmask, :method, :family, :onboot, :mtu, :mode, :options].each do |property|
       describe property do
         it { described_class.attrtype(property).should == :property }
       end
@@ -196,6 +196,22 @@ describe Puppet::Type.type(:network_config) do
         expect do
           described_class.new(:name => 'yay', :mtu => '1500.1')
         end.to raise_error
+      end
+    end
+
+    describe 'mode' do
+      [:raw, :vlan].each do |value|
+        it "should accept '#{value}' for interface mode" do
+          described_class.new(:name => 'yay', :mode => value)
+        end
+      end
+      it "should fail on undefined values" do
+        expect do
+          described_class.new(:name => 'yay', :mode => 'foo')
+        end.to raise_error
+      end
+      it "should default to :raw" do
+        described_class.new(:name => 'yay')[:mode].should == :raw
       end
     end
 


### PR DESCRIPTION
This PR adds a `mode` parameter to the `network_config` type which is intended to describe in the interface is a regular untagged ethernet interface, a tagged vlan interface, a bond group, a tunnel, etc..  At present only `:raw` and `:vlan` are supported mode with the default being `:raw` but the hope is that ~`:bond` can be added in the near future.

In this implementation the raw device that a new vlan is configured on is inherently implied by the name of the `:vlan` mode interface.  An alternative to making the raw interface name implicit would be to track the the name of the `:raw` interface a vlan is dependent on.  However, that raises some resource dep. issues which I feel can be added on to this minimal implementation.

The design of this implementation is discussed in https://github.com/adrienthebo/puppet-network/issues/48