### PR TITLE
Fix static route rhel

### DIFF
--- a/lib/puppet/provider/network_route/redhat.rb
+++ b/lib/puppet/provider/network_route/redhat.rb
@@ -89,7 +89,13 @@ Puppet::Type.type(:network_route).provide(:redhat) do
       if provider.network == "default"
         contents << "#{provider.network} via #{provider.gateway} dev #{provider.interface}\n"
       else
-        contents << "#{provider.network}/#{provider.netmask} via #{provider.gateway} dev #{provider.interface}\n"
+        # Always use netmask in CIDR notation
+        if provider.netmask.include?('.')
+          netmask_cidr = "#{IPAddr.new(provider.netmask).to_i.to_s(2).count('1')}"
+        else
+          netmask_cidr = provider.netmask
+        end
+        contents << "#{provider.network}/#{netmask_cidr} via #{provider.gateway} dev #{provider.interface}\n"
       end
     end
     contents.join

--- a/lib/puppet/provider/network_route/redhat.rb
+++ b/lib/puppet/provider/network_route/redhat.rb
@@ -55,7 +55,14 @@ Puppet::Type.type(:network_route).provide(:redhat) do
       else
         # use the CIDR version of the target as :name
         network, netmask = route[0].split("/")
-        cidr_target = "#{network}/#{IPAddr.new(netmask).to_i.to_s(2).count('1')}"
+        # netmask in dot-decimal notation for route specification
+        if netmask.include?('.')
+          netmask_cidr = "#{IPAddr.new(netmask).to_i.to_s(2).count('1')}"
+        else
+          netmask_cidr = netmask
+          netmask = "#{IPAddr.new(route[0]).inspect.split('/')[1].match(/[0-9\.]+/)}"
+        end
+        cidr_target = "#{network}/#{netmask_cidr}"
 
         new_route[:name]    = cidr_target
         new_route[:network] = network


### PR DESCRIPTION
Hello,
Here is a dirty patch allowing us to specify static routes on Scientific Linux 5 (rhel 5-like).
It should address problems mentionned in #58.
It allows the following to be specified:
```
network_route { '10.8.0.0/24':
  ensure    => 'present',
  gateway   => '172.20.8.1',
  interface => 'eth1',
  network   => '10.8.0.0',
  netmask   => '255.255.255.0',
}
network_route { '10.8.1.0/24':
  ensure    => 'present',
  gateway   => '172.20.8.1',
  interface => 'eth1',
  network   => '10.8.1.0',
  netmask   => '24',
}
```
Genreating the following configuration in /etc/sysconfig/network-scripts/route-eth1:
```
10.8.0.0/24 via 172.20.8.1 dev eth1
10.8.1.0/24 via 172.20.8.1 dev eth1
```
So netmask can be provided as 255.255.255.0 or 24 (without useless resource refresh).