### PR TITLE
Ommit lacp_rate for non 802.3ad mode

### DIFF
--- a/manifests/bond.pp
+++ b/manifests/bond.pp
@@ -129,12 +129,12 @@ define network::bond(
   $method    = undef,
   $family    = undef,
   $onboot    = undef,
+  $lacp_rate = undef,
 
   $mode             = "active-backup",
   $miimon           = "100",
   $downdelay        = "200",
   $updelay          = "200",
-  $lacp_rate        = "slow",
   $primary          = $slaves[0],
   $primary_reselect = "always",
   $xmit_hash_policy = "layer2",


### PR DESCRIPTION
Remove cause for warning:

bonding: bond1: Unable to update LACP rate because bond is not in 802.3ad mode.