### PR TITLE
Fix: do not print properies if they are absent.

### DIFF
--- a/lib/puppet/provider/network_config/interfaces.rb
+++ b/lib/puppet/provider/network_config/interfaces.rb
@@ -273,7 +273,7 @@ Puppet::Type.type(:network_config).provide(:interfaces) do
         [:netmask,   'netmask'],
         [:mtu,       'mtu'],
       ].each do |(property, section)|
-        stanza << "#{section} #{provider.send property}" if provider.send(property) and provider.send(propery) != 'absent'
+        stanza << "#{section} #{provider.send property}" if provider.send(property) and provider.send(property).to_s != 'absent'
       end
 
       if provider.options

--- a/lib/puppet/provider/network_config/interfaces.rb
+++ b/lib/puppet/provider/network_config/interfaces.rb
@@ -273,7 +273,7 @@ Puppet::Type.type(:network_config).provide(:interfaces) do
         [:netmask,   'netmask'],
         [:mtu,       'mtu'],
       ].each do |(property, section)|
-        stanza << "#{section} #{provider.send property}" if provider.send(property)
+        stanza << "#{section} #{provider.send property}" if provider.send(property) and provider.send(propery) != 'absent'
       end
 
       if provider.options

--- a/lib/puppet/provider/network_config/interfaces.rb
+++ b/lib/puppet/provider/network_config/interfaces.rb
@@ -273,10 +273,10 @@ Puppet::Type.type(:network_config).provide(:interfaces) do
         [:netmask,   'netmask'],
         [:mtu,       'mtu'],
       ].each do |(property, section)|
-        stanza << "#{section} #{provider.send property}" if provider.send(property) and provider.send(property).to_s != 'absent'
+        stanza << "#{section} #{provider.send property}" if provider.send(property) and provider.send(property) != :absent
       end
 
-      if provider.options
+      if provider.options and provider.options != :absent
         provider.options.each_pair do |key, val|
           if val.is_a? String
             stanza << "    #{key} #{val}"


### PR DESCRIPTION
The previous check was wrong because the "provider.send(propery)" returns a string and was always true.