### PR TITLE
Use ifcfg script name in case DEVICE parameter is not specified on redhat network_config provider

### DIFF
--- a/lib/puppet/provider/network_config/redhat.rb
+++ b/lib/puppet/provider/network_config/redhat.rb
@@ -121,6 +121,12 @@ Puppet::Type.type(:network_config).provide(:redhat) do
     #
     props.merge!({:family => :inet})
 
+    # If there is no DEVICE property in the interface configuration we retrieve
+    # the interface name from the file name itself
+    unless props.has_key?(:name)
+        props.merge!({:name => filename.split("ifcfg-")[1]})
+    end
+
     # The FileMapper mixin expects an array of providers, so we return the
     # single interface wrapped in an array
     [props]

--- a/spec/fixtures/provider/network_config/redhat_spec/eth1-dhcp
+++ b/spec/fixtures/provider/network_config/redhat_spec/eth1-dhcp
@@ -1,0 +1,5 @@
+# Advanced Micro Devices [AMD] 79c970 [PCnet32 LANCE]
+BOOTPROTO=dhcp
+DHCPCLASS=
+HWADDR=00:50:56:B2:00:1B
+ONBOOT=yes

--- a/spec/unit/provider/network_config/redhat_spec.rb
+++ b/spec/unit/provider/network_config/redhat_spec.rb
@@ -319,6 +319,11 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
       end
     end
 
+    describe 'when DEVICE is not present' do
+      let(:data) { described_class.parse_file('ifcfg-eth1', fixture_data('eth1-dhcp'))[0] }
+      it { data[:name].should == 'eth1' }
+    end
+
   end
 
   describe "when formatting resources" do
@@ -430,7 +435,7 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
       File.expects(:unlink).never
       described_class.stubs(:perform_write)
       described_class.dirty_file!('/not/a/real/file')
-      described_class.flush_file('/not/a/real/file') 
+      described_class.flush_file('/not/a/real/file')
     }
   end
 end


### PR DESCRIPTION
In network_config redhat provider, if DEVICE is not present in a ifcfg script file, filemapper
will fail to parse that file. With this change, if the parameter is not present, the name of
the ifcfg file itself is used.