### PR TITLE
On Debian write only non-empty auto/allow-hotplug interface parameters

### DIFF
--- a/lib/puppet/provider/network_config/interfaces.rb
+++ b/lib/puppet/provider/network_config/interfaces.rb
@@ -247,19 +247,20 @@ Puppet::Type.type(:network_config).provide(:interfaces) do
     contents << header
 
     # Add onboot interfaces
-    if (auto_interfaces = providers.select {|provider| provider.onboot == true })
+    auto_interfaces = providers.select {|provider| provider.onboot == true }
+    unless (auto_interfaces.empty?)
       stanza = []
       stanza << "auto " + auto_interfaces.map(&:name).sort.join(" ")
       contents << stanza.join("\n")
     end
 
     # Add hotpluggable interfaces
-    if (hotplug_interfaces = providers.select {|provider| provider.hotplug == true })
+    hotplug_interfaces = providers.select {|provider| provider.hotplug == true }
+    unless (hotplug_interfaces.empty?)
       stanza = []
       stanza << "allow-hotplug " + hotplug_interfaces.map(&:name).sort.join(" ")
       contents << stanza.join("\n")
     end
-
 
     # Build iface stanzas
     providers.sort_by(&:name).each do |provider|

--- a/spec/unit/provider/network_config/interfaces_spec.rb
+++ b/spec/unit/provider/network_config/interfaces_spec.rb
@@ -211,7 +211,7 @@ describe Puppet::Type.type(:network_config).provider(:interfaces) do
       stub('lo_provider',
         :name            => "lo",
         :onboot          => true,
-        :hotplug         => true,
+        :hotplug         => false,
         :family          => "inet",
         :method          => "loopback",
         :ipaddress       => nil,
@@ -230,21 +230,37 @@ describe Puppet::Type.type(:network_config).provider(:interfaces) do
 
     describe "writing the auto section" do
       it "should allow at most one section" do
-        content.scan(/^auto .*$/).length.should == 1
+        content.scan(/^auto .+$/).length.should == 1
       end
 
       it "should have the correct interfaces appended" do
-        content.scan(/^auto .*$/).first.should match("auto eth0 lo")
+        content.scan(/^auto .+$/).first.should match("auto eth0 lo")
+      end
+    end
+
+    describe "writing only the auto section" do
+      let(:content) { described_class.format_file('', [lo_provider]) }
+
+      it "should skip the allow-hotplug line" do
+        content.scan(/^allow-hotplug .*$/).length.should == 0
       end
     end
 
     describe "writing the allow-hotplug section" do
       it "should allow at most one section" do
-        content.scan(/^allow-hotplug .*$/).length.should == 1
+        content.scan(/^allow-hotplug .+$/).length.should == 1
       end
 
       it "should have the correct interfaces appended" do
-        content.scan(/^allow-hotplug .*$/).first.should match("allow-hotplug eth0 eth1 lo")
+        content.scan(/^allow-hotplug .+$/).first.should match("allow-hotplug eth0 eth1")
+      end
+    end
+
+    describe "writing only the allow-hotplug section" do
+      let(:content) { described_class.format_file('', [eth1_provider]) }
+
+      it "should skip the auto line" do
+        content.scan(/^auto .*$/).length.should == 0
       end
     end
 


### PR DESCRIPTION
Even if there is no hotplug interface on Debian Wheezy, the interfaces provider generates configuration line with no interface. This can make problems to Augeas, when it fails to read whole file due to parse error on this empty parameter.

Example of generated configuration:

```
auto eth3 lo
allow-hotplug
iface eth3 inet dhcp
iface lo inet loopback
```

This fails on:

```
/augeas/files/etc/network/interfaces/error = "parse_failed"
/augeas/files/etc/network/interfaces/error/pos = "13"
/augeas/files/etc/network/interfaces/error/line = "2"
/augeas/files/etc/network/interfaces/error/char = "0"
/augeas/files/etc/network/interfaces/error/lens = "/usr/share/augeas/lenses/dist/interfaces.aug:101.13-.63:"
/augeas/files/etc/network/interfaces/error/message = "Get did not match entire input"
```

In following simple patch the *auto* and *allow-hotplug* parameters are first checked for any existing interface. If there is any, the configuration line is written. Otherwise the configuration parameter (line) is skipped.