### PR TITLE
Set mode "raw" to existing non-VLAN interfaces on Debian

### DIFF
--- a/lib/puppet/provider/network_config/interfaces.rb
+++ b/lib/puppet/provider/network_config/interfaces.rb
@@ -190,6 +190,7 @@ Puppet::Type.type(:network_config).provide(:interfaces) do
           #Instance[name].name   = name
           Instance[name].family = family
           Instance[name].method = method
+          Instance[name].mode   = :raw
 
         else
           # If we match on a string with a leading iface, but it isn't in the

--- a/spec/unit/provider/network_config/interfaces_spec.rb
+++ b/spec/unit/provider/network_config/interfaces_spec.rb
@@ -47,6 +47,7 @@ describe Puppet::Type.type(:network_config).provider(:interfaces) do
       data.find { |h| h[:name] == "eth0" }.should == {
         :family  => "inet",
         :method  => "dhcp",
+        :mode    => :raw,
         :name    => "eth0",
         :hotplug => true,
         :options => {},
@@ -59,6 +60,7 @@ describe Puppet::Type.type(:network_config).provider(:interfaces) do
       data.find { |h| h[:name] == "eth0" }.should == {
         :family  => "inet",
         :method  => "dhcp",
+        :mode    => :raw,
         :name    => "eth0",
         :hotplug => true,
         :options => {},
@@ -72,6 +74,7 @@ describe Puppet::Type.type(:network_config).provider(:interfaces) do
         :name      => "eth0",
         :family    => "inet",
         :method    => "static",
+        :mode      => :raw,
         :ipaddress => "192.168.0.2",
         :netmask   => "255.255.255.0",
         :onboot    => true,
@@ -94,6 +97,7 @@ describe Puppet::Type.type(:network_config).provider(:interfaces) do
         :name      => "eth0",
         :family    => "inet",
         :method    => "dhcp",
+        :mode      => :raw,
         :options   => {
           "pre-up" => "/bin/touch /tmp/eth0-up",
           "post-down" => [
@@ -111,6 +115,7 @@ describe Puppet::Type.type(:network_config).provider(:interfaces) do
         :name      => "eth0",
         :family    => "inet",
         :method    => "static",
+        :mode      => :raw,
         :ipaddress => "192.168.0.2",
         :netmask   => "255.255.255.0",
         :onboot    => true,


### PR DESCRIPTION
When reading interfaces configuration on Debian, "raw" mode isn't set for non-VLAN interfaces. Puppet then fixes the mode from undefined to raw again and again and again with every run. E.g.:

```
Notice: /Stage[main]/Network_config[ib0]/mode: mode changed '' to 'raw'
```

Following simple patch fixes this behaviour on Debian, including tests.