### PR TITLE
Bond improvements

### DIFF
--- a/manifests/bond.pp
+++ b/manifests/bond.pp
@@ -28,6 +28,10 @@
 #
 # Whether to bring the interface up on boot.
 #
+# [*hotplug*]
+#
+# Whether to allow hotplug for the interface.
+#
 # [*options*]
 #
 # Hash with custom interfaces options.
@@ -137,6 +141,7 @@ define network::bond(
   $method           = undef,
   $family           = undef,
   $onboot           = undef,
+  $hotplug          = undef,
   $lacp_rate        = undef,
   $options          = undef,
   $slave_options    = undef,
@@ -167,6 +172,7 @@ define network::bond(
         method           => $method,
         family           => $family,
         onboot           => $onboot,
+        hotplug          => $hotplug,
         options          => $options,
         slave_options    => $slave_options,
 
@@ -191,6 +197,7 @@ define network::bond(
         family           => $family,
         method           => $method,
         onboot           => $onboot,
+        hotplug          => $hotplug,
         options          => $options,
         slave_options    => $slave_options,
 

--- a/manifests/bond.pp
+++ b/manifests/bond.pp
@@ -131,15 +131,15 @@
 #
 define network::bond(
   $slaves,
-  $ensure    = present,
-  $ipaddress = undef,
-  $netmask   = undef,
-  $method    = undef,
-  $family    = undef,
-  $onboot    = undef,
-  $lacp_rate = undef,
-  $options   = undef,
-  $slave_options = undef,
+  $ensure           = present,
+  $ipaddress        = undef,
+  $netmask          = undef,
+  $method           = undef,
+  $family           = undef,
+  $onboot           = undef,
+  $lacp_rate        = undef,
+  $options          = undef,
+  $slave_options    = undef,
 
   $mode             = "active-backup",
   $miimon           = "100",
@@ -160,14 +160,14 @@ define network::bond(
   case $::osfamily {
     Debian: {
       network::bond::debian { $name:
-        ensure    => $ensure,
-        slaves    => $slaves,
-        ipaddress => $ipaddress,
-        netmask   => $netmask,
-        method    => $method,
-        family    => $family,
-        onboot    => $onboot,
-        options   => $options,
+        ensure           => $ensure,
+        slaves           => $slaves,
+        ipaddress        => $ipaddress,
+        netmask          => $netmask,
+        method           => $method,
+        family           => $family,
+        onboot           => $onboot,
+        options          => $options,
         slave_options    => $slave_options,
 
         mode             => $mode,
@@ -179,19 +179,19 @@ define network::bond(
         primary_reselect => $primary_reselect,
         xmit_hash_policy => $xmit_hash_policy,
 
-        require   => Kmod::Alias[$name],
+        require          => Kmod::Alias[$name],
       }
     }
     RedHat: {
       network::bond::redhat { $name:
-        ensure    => $ensure,
-        slaves    => $slaves,
-        ipaddress => $ipaddress,
-        netmask   => $netmask,
-        family    => $family,
-        method    => $method,
-        onboot    => $onboot,
-        options   => $options,
+        ensure           => $ensure,
+        slaves           => $slaves,
+        ipaddress        => $ipaddress,
+        netmask          => $netmask,
+        family           => $family,
+        method           => $method,
+        onboot           => $onboot,
+        options          => $options,
         slave_options    => $slave_options,
 
         mode             => $mode,
@@ -203,7 +203,7 @@ define network::bond(
         primary_reselect => $primary_reselect,
         xmit_hash_policy => $xmit_hash_policy,
 
-        require   => Kmod::Alias[$name],
+        require          => Kmod::Alias[$name],
       }
     }
     default: {

--- a/manifests/bond.pp
+++ b/manifests/bond.pp
@@ -28,6 +28,14 @@
 #
 # Whether to bring the interface up on boot.
 #
+# [*options*]
+#
+# Hash with custom interfaces options.
+#
+# [*slave_options*]
+#
+# Hash with custom slave interfaces options.
+#
 # === bonding parameters
 #
 # [*slaves*]
@@ -130,6 +138,8 @@ define network::bond(
   $family    = undef,
   $onboot    = undef,
   $lacp_rate = undef,
+  $options   = undef,
+  $slave_options = undef,
 
   $mode             = "active-backup",
   $miimon           = "100",
@@ -143,20 +153,22 @@ define network::bond(
   require network::bond::setup
 
   kmod::alias { $name:
-    source => 'bonding',
     ensure => $ensure,
+    source => 'bonding',
   }
 
   case $::osfamily {
     Debian: {
       network::bond::debian { $name:
-        slaves    => $slaves,
         ensure    => $ensure,
+        slaves    => $slaves,
         ipaddress => $ipaddress,
         netmask   => $netmask,
         method    => $method,
         family    => $family,
         onboot    => $onboot,
+        options   => $options,
+        slave_options    => $slave_options,
 
         mode             => $mode,
         miimon           => $miimon,
@@ -172,13 +184,15 @@ define network::bond(
     }
     RedHat: {
       network::bond::redhat { $name:
-        slaves    => $slaves,
         ensure    => $ensure,
+        slaves    => $slaves,
         ipaddress => $ipaddress,
         netmask   => $netmask,
         family    => $family,
         method    => $method,
         onboot    => $onboot,
+        options   => $options,
+        slave_options    => $slave_options,
 
         mode             => $mode,
         miimon           => $miimon,

--- a/manifests/bond/debian.pp
+++ b/manifests/bond/debian.pp
@@ -13,6 +13,8 @@ define network::bond::debian(
   $method    = undef,
   $family    = undef,
   $onboot    = undef,
+  $options   = undef,
+  $slave_options    = undef,
 
   $mode             = undef,
   $miimon           = undef,
@@ -36,7 +38,7 @@ define network::bond::debian(
     'bond-xmit-hash-policy' => $xmit_hash_policy,
   }
 
-  $opts = compact_hash($raw)
+  $opts = compact_hash(merge($raw, $options))
 
   network_config { $name:
     ensure    => $ensure,

--- a/manifests/bond/debian.pp
+++ b/manifests/bond/debian.pp
@@ -7,13 +7,13 @@
 # * Debian Network Bonding http://wiki.debian.org/Bonding
 define network::bond::debian(
   $slaves,
-  $ensure    = present,
-  $ipaddress = undef,
-  $netmask   = undef,
-  $method    = undef,
-  $family    = undef,
-  $onboot    = undef,
-  $options   = undef,
+  $ensure           = present,
+  $ipaddress        = undef,
+  $netmask          = undef,
+  $method           = undef,
+  $family           = undef,
+  $onboot           = undef,
+  $options          = undef,
   $slave_options    = undef,
 
   $mode             = undef,
@@ -27,13 +27,13 @@ define network::bond::debian(
 ) {
 
   $raw = {
-    'bond-slaves'    => join($slaves, ' '),
-    'bond-mode'      => $mode,
-    'bond-miimon'    => $miimon,
-    'bond-downdelay' => $downdelay,
-    'bond-updelay'   => $updelay,
-    'bond-lacp-rate' => $lacp_rate,
-    'bond-primary'   => $primary,
+    'bond-slaves'           => join($slaves, ' '),
+    'bond-mode'             => $mode,
+    'bond-miimon'           => $miimon,
+    'bond-downdelay'        => $downdelay,
+    'bond-updelay'          => $updelay,
+    'bond-lacp-rate'        => $lacp_rate,
+    'bond-primary'          => $primary,
     'bond-primary-reselect' => $primary_reselect,
     'bond-xmit-hash-policy' => $xmit_hash_policy,
   }

--- a/manifests/bond/debian.pp
+++ b/manifests/bond/debian.pp
@@ -13,6 +13,7 @@ define network::bond::debian(
   $method           = undef,
   $family           = undef,
   $onboot           = undef,
+  $hotplug          = undef,
   $options          = undef,
   $slave_options    = undef,
 
@@ -47,6 +48,7 @@ define network::bond::debian(
     family    => $family,
     method    => $method,
     onboot    => $onboot,
+    hotplug   => $hotplug,
     options   => $opts,
   }
 

--- a/manifests/bond/redhat.pp
+++ b/manifests/bond/redhat.pp
@@ -8,13 +8,13 @@
 #
 define network::bond::redhat(
   $slaves,
-  $ensure    = present,
-  $ipaddress = undef,
-  $netmask   = undef,
-  $method    = undef,
-  $family    = undef,
-  $onboot    = undef,
-  $options   = undef,
+  $ensure           = present,
+  $ipaddress        = undef,
+  $netmask          = undef,
+  $method           = undef,
+  $family           = undef,
+  $onboot           = undef,
+  $options          = undef,
   $slave_options    = undef,
 
   $mode             = undef,

--- a/manifests/bond/redhat.pp
+++ b/manifests/bond/redhat.pp
@@ -14,6 +14,7 @@ define network::bond::redhat(
   $method           = undef,
   $family           = undef,
   $onboot           = undef,
+  $hotplug          = undef,
   $options          = undef,
   $slave_options    = undef,
 
@@ -39,6 +40,7 @@ define network::bond::redhat(
     netmask   => $netmask,
     family    => $family,
     onboot    => $onboot,
+    hotplug   => $hotplug,
     options   => $opts,
   }
 
@@ -53,6 +55,7 @@ define network::bond::redhat(
     ensure  => $ensure,
     method  => static,
     onboot  => true,
+    hotplug => false,
     options => $opts_slave,
   }
 }

--- a/manifests/bond/redhat.pp
+++ b/manifests/bond/redhat.pp
@@ -14,6 +14,8 @@ define network::bond::redhat(
   $method    = undef,
   $family    = undef,
   $onboot    = undef,
+  $options   = undef,
+  $slave_options    = undef,
 
   $mode             = undef,
   $miimon           = undef,
@@ -25,7 +27,10 @@ define network::bond::redhat(
   $xmit_hash_policy = undef,
 ) {
 
-  $bonding_opts = template("network/bond/opts-redhat.erb")
+  $opts = merge(
+    { 'BONDING_OPTS' => template('network/bond/opts-redhat.erb'), },
+    $options
+  )
 
   network_config { $name:
     ensure    => $ensure,
@@ -34,19 +39,21 @@ define network::bond::redhat(
     netmask   => $netmask,
     family    => $family,
     onboot    => $onboot,
-    options          => {
-      'BONDING_OPTS' => $bonding_opts,
-    }
+    options   => $opts,
   }
 
+
+  $opts_slave = merge(
+    { 'MASTER' => $name,
+      'SLAVE'  =>'yes' },
+    $slave_options
+  )
+
   network_config { $slaves:
-    ensure => $ensure,
-    method => static,
-    onboot => true,
-    options    => {
-      'MASTER' => $name,
-      'SLAVE'  => 'yes',
-    }
+    ensure  => $ensure,
+    method  => static,
+    onboot  => true,
+    options => $opts_slave,
   }
 }
 

--- a/spec/defines/bond/debian_spec.rb
+++ b/spec/defines/bond/debian_spec.rb
@@ -60,6 +60,7 @@ describe 'network::bond::debian', :type => :define do
         'slaves'           => ['eth0', 'eth1', 'eth2'],
         'options'          => { 'bond-future-option' => 'yes' },
         'slave_options'    => { 'slave-future-option' => 'no' },
+        'hotplug'          => 'false',
 
         'mode'             => 'balance-rr',
         'miimon'           => '50',
@@ -81,6 +82,7 @@ describe 'network::bond::debian', :type => :define do
         'method'         => 'static',
         'ipaddress'      => '10.20.2.1',
         'netmask'        => '255.255.255.192',
+        'hotplug'        => false,
         'options'        => {
           'bond-slaves'           => 'eth0 eth1 eth2',
           'bond-mode'             => 'balance-rr',

--- a/spec/defines/bond/debian_spec.rb
+++ b/spec/defines/bond/debian_spec.rb
@@ -53,11 +53,13 @@ describe 'network::bond::debian', :type => :define do
   describe "with non-default bonding params" do
     let(:params) do
       {
-        'ensure'    => 'present',
-        'method'    => 'static',
-        'ipaddress' => '10.20.2.1',
-        'netmask'   => '255.255.255.192',
-        'slaves'    => ['eth0', 'eth1', 'eth2'],
+        'ensure'           => 'present',
+        'method'           => 'static',
+        'ipaddress'        => '10.20.2.1',
+        'netmask'          => '255.255.255.192',
+        'slaves'           => ['eth0', 'eth1', 'eth2'],
+        'options'          => { 'bond-future-option' => 'yes' },
+        'slave_options'    => { 'slave-future-option' => 'no' },
 
         'mode'             => 'balance-rr',
         'miimon'           => '50',
@@ -87,6 +89,7 @@ describe 'network::bond::debian', :type => :define do
           'bond-updelay'          => '100',
           'bond-lacp-rate'        => 'fast',
           'bond-xmit-hash-policy' => 'layer3+4',
+          'bond-future-option'    => 'yes'
         },
       })
     end

--- a/spec/defines/bond/redhat_spec.rb
+++ b/spec/defines/bond/redhat_spec.rb
@@ -26,9 +26,10 @@ describe 'network::bond::redhat', :type => :define do
     ['eth0', 'eth1'].each do |slave|
       it "should add a network_config resource for #{slave}" do
         should contain_network_config(slave).with({
-          'ensure' => 'present',
-          'method' => 'static',
-          'onboot' => true,
+          'ensure'  => 'present',
+          'method'  => 'static',
+          'onboot'  => true,
+          'hotplug' => false,
           'options'  => {
             'MASTER' => 'bond0',
             'SLAVE'  => 'yes',
@@ -60,6 +61,7 @@ describe 'network::bond::redhat', :type => :define do
         'slaves'           => ['eth0', 'eth1', 'eth2'],
         'options'          => { 'NM_CONTROLLED' => 'yes' },
         'slave_options'    => { 'NM_CONTROLLED' => 'no' },
+        'hotplug'          => 'false',
 
         'mode'             => 'balance-rr',
         'miimon'           => '50',
@@ -75,6 +77,7 @@ describe 'network::bond::redhat', :type => :define do
           'ensure'  => 'present',
           'method'  => 'static',
           'onboot'  => true,
+          'hotplug' => false,
           'options' => {
             'MASTER'        => 'bond0',
             'SLAVE'         => 'yes',
@@ -90,6 +93,7 @@ describe 'network::bond::redhat', :type => :define do
         'method'    => 'static',
         'ipaddress' => '10.20.2.1',
         'netmask'   => '255.255.255.192',
+        'hotplug'   => false,
         'options'   => {
           'BONDING_OPTS'  => 'mode=balance-rr miimon=50 downdelay=100 updelay=100 lacp_rate=fast xmit_hash_policy=layer3+4',
           'NM_CONTROLLED' => 'yes',

--- a/spec/defines/bond/redhat_spec.rb
+++ b/spec/defines/bond/redhat_spec.rb
@@ -53,11 +53,13 @@ describe 'network::bond::redhat', :type => :define do
   describe "with non-default bonding params" do
     let(:params) do
       {
-        'ensure'    => 'present',
-        'method'    => 'static',
-        'ipaddress' => '10.20.2.1',
-        'netmask'   => '255.255.255.192',
-        'slaves'    => ['eth0', 'eth1', 'eth2'],
+        'ensure'           => 'present',
+        'method'           => 'static',
+        'ipaddress'        => '10.20.2.1',
+        'netmask'          => '255.255.255.192',
+        'slaves'           => ['eth0', 'eth1', 'eth2'],
+        'options'          => { 'NM_CONTROLLED' => 'yes' },
+        'slave_options'    => { 'NM_CONTROLLED' => 'no' },
 
         'mode'             => 'balance-rr',
         'miimon'           => '50',
@@ -70,12 +72,13 @@ describe 'network::bond::redhat', :type => :define do
     ['eth0', 'eth1', 'eth2'].each do |slave|
       it "should add a network_config resource for #{slave}" do
         should contain_network_config(slave).with({
-          'ensure' => 'present',
-          'method' => 'static',
-          'onboot' => true,
-          'options'  => {
-            'MASTER' => 'bond0',
-            'SLAVE'  => 'yes',
+          'ensure'  => 'present',
+          'method'  => 'static',
+          'onboot'  => true,
+          'options' => {
+            'MASTER'        => 'bond0',
+            'SLAVE'         => 'yes',
+            'NM_CONTROLLED' => 'no',
           },
         })
       end
@@ -83,12 +86,13 @@ describe 'network::bond::redhat', :type => :define do
 
     it "should add a network_config resource for bond0" do
       should contain_network_config('bond0').with({
-        'ensure'         => 'present',
-        'method'         => 'static',
-        'ipaddress'      => '10.20.2.1',
-        'netmask'        => '255.255.255.192',
-        'options'        => {
-          'BONDING_OPTS' => 'mode=balance-rr miimon=50 downdelay=100 updelay=100 lacp_rate=fast xmit_hash_policy=layer3+4',
+        'ensure'    => 'present',
+        'method'    => 'static',
+        'ipaddress' => '10.20.2.1',
+        'netmask'   => '255.255.255.192',
+        'options'   => {
+          'BONDING_OPTS'  => 'mode=balance-rr miimon=50 downdelay=100 updelay=100 lacp_rate=fast xmit_hash_policy=layer3+4',
+          'NM_CONTROLLED' => 'yes',
         },
       })
     end

--- a/spec/defines/bond_spec.rb
+++ b/spec/defines/bond_spec.rb
@@ -10,6 +10,8 @@ describe 'network::bond', :type => :define do
       'ipaddress' => '172.18.1.2',
       'netmask'   => '255.255.128.0',
       'slaves'    => ['eth0', 'eth1'],
+      'options'   => { 'NM_CONTROLLED' => 'no' },
+      'slave_options'    => { 'NM_CONTROLLED' => 'yes' },
 
       'mode'             => 'active-backup',
       'miimon'           => '100',

--- a/spec/defines/bond_spec.rb
+++ b/spec/defines/bond_spec.rb
@@ -5,13 +5,13 @@ describe 'network::bond', :type => :define do
 
   let(:params) do
     {
-      'ensure'    => 'present',
-      'method'    => 'static',
-      'ipaddress' => '172.18.1.2',
-      'netmask'   => '255.255.128.0',
-      'slaves'    => ['eth0', 'eth1'],
-      'options'   => { 'NM_CONTROLLED' => 'no' },
-      'slave_options'    => { 'NM_CONTROLLED' => 'yes' },
+      'ensure'           => 'present',
+      'method'           => 'static',
+      'ipaddress'        => '172.18.1.2',
+      'netmask'          => '255.255.128.0',
+      'slaves'           => ['eth0', 'eth1'],
+      'options'          => { 'NM_CONTROLLED' => 'yes' },
+      'slave_options'    => { 'NM_CONTROLLED' => 'no' },
 
       'mode'             => 'active-backup',
       'miimon'           => '100',


### PR DESCRIPTION
Following simple patches introduce 3 options for defined resource network::bond{ }.

* __hotplug__ which is propagated to bond interface (user usually wants to set to non-default *false*)
* __options__ which is merged with bonding options (user can use it to set additional options on bond interface, e.g. disable network manager or set bridge interface for more advanced configuration)
* __slave_options__ which is merged with MASTER/SLAVE options on bond slave interfaces 

For example on Red Hat I can now easily disable Network Manager on all interfaces and set bridge over bond and also disable hotplug, which doesn't have sense for these interfaces:

```puppet
network::bond { 'bond0':
  ensure  => present,
  onboot  => 'true',
  hotplug => 'false',
  slaves  => ['ens1f0','ens1f1'],
  mode    => 'active-backup',
  options => {
    'BRIDGE'        => 'br0',
    'NM_CONTROLLED' => 'no',
  },
  slave_options => {
    'NM_CONTROLLED' => 'no',
  },
}
```