### PR TITLE
Fix test runs by using strings as cases for $::osfamily

### DIFF
--- a/manifests/bond.pp
+++ b/manifests/bond.pp
@@ -163,7 +163,7 @@ define network::bond(
   }
 
   case $::osfamily {
-    Debian: {
+    'Debian': {
       network::bond::debian { $name:
         ensure           => $ensure,
         slaves           => $slaves,
@@ -188,7 +188,7 @@ define network::bond(
         require          => Kmod::Alias[$name],
       }
     }
-    RedHat: {
+    'RedHat': {
       network::bond::redhat { $name:
         ensure           => $ensure,
         slaves           => $slaves,


### PR DESCRIPTION
With these two changes the tests run through on my machine (after removing puppet-kmod's augeas checks…). This needs #109 however.