### PR TITLE
Contain instead of deprecated include

### DIFF
--- a/manifests/bond.pp
+++ b/manifests/bond.pp
@@ -163,7 +163,7 @@ define network::bond(
   }
 
   case $::osfamily {
-    Debian: {
+    'Debian': {
       network::bond::debian { $name:
         ensure           => $ensure,
         slaves           => $slaves,
@@ -188,7 +188,7 @@ define network::bond(
         require          => Kmod::Alias[$name],
       }
     }
-    RedHat: {
+    'RedHat': {
       network::bond::redhat { $name:
         ensure           => $ensure,
         slaves           => $slaves,

--- a/spec/defines/bond_spec.rb
+++ b/spec/defines/bond_spec.rb
@@ -61,7 +61,7 @@ describe 'network::bond', :type => :define do
   describe 'configuring the kernel bonding device' do
     let(:facts) {{:osfamily => 'Debian'}}
 
-    it { should include_class('network::bond::setup') }
+    it { should contain_class('network::bond::setup') }
 
     it "should add a kernel module alias for the bonded device" do
       should contain_kmod__alias('bond0').with({


### PR DESCRIPTION
This fixes the deprecation warnings in the tests.