### PR TITLE
Allow an empty hash for options

### DIFF
--- a/lib/puppet/provider/network_config/redhat.rb
+++ b/lib/puppet/provider/network_config/redhat.rb
@@ -168,7 +168,7 @@ Puppet::Type.type(:network_config).provide(:redhat) do
     end
 
     # For all of the remaining values, blindly toss them into the options hash.
-    props[:options] = pairs unless pairs.empty?
+    props[:options] = pairs
 
     [:onboot, :hotplug].each do |bool_property|
       if props[bool_property]

--- a/spec/fixtures/provider/network_config/redhat_spec/eth1-simple
+++ b/spec/fixtures/provider/network_config/redhat_spec/eth1-simple
@@ -1,0 +1,4 @@
+BOOTPROTO=dhcp
+ONBOOT=yes
+DEVICE=eth1
+HOTPLUG=yes

--- a/spec/unit/provider/network_config/redhat_spec.rb
+++ b/spec/unit/provider/network_config/redhat_spec.rb
@@ -94,6 +94,11 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
       it { data[:options]["NM_CONTROLLED"].should == 'no' }
     end
 
+    describe 'with no extra options' do
+      let(:data) { described_class.parse_file('eth0', fixture_data('eth1-simple'))[0] }
+      it { data[:options].should == {} }
+    end
+
     describe 'complex configuration' do
       let(:virbonding_path) { File.join(PROJECT_ROOT, 'spec', 'fixtures', 'provider', 'network_config', 'redhat_spec', 'virbonding') }
 
@@ -199,7 +204,7 @@ describe Puppet::Type.type(:network_config).provider(:redhat) do
         its(:netmask)   { should == '255.255.255.0' }
         its(:onboot)    { should == :absent }
         its(:method)    { should == 'static' }
-        its(:options)   { should == :absent }
+        its(:options)   { should == {} }
       end
 
       describe 'vlan200' do


### PR DESCRIPTION
Set :options to a empty hash in cases where there are no
extra options in the parsed file. Without this newproperty.is_to_s
raises an exception as it tries to find the keys of nil.